### PR TITLE
Change mysql docker image to mariadb:jammy

### DIFF
--- a/apps/mysql/Dockerfile
+++ b/apps/mysql/Dockerfile
@@ -1,4 +1,5 @@
-FROM mysql
+#FROM mysql
+FROM mariadb:jammy
 
 COPY ./01_customers.sql.gz /docker-entrypoint-initdb.d/01_customers.sql.gz
 COPY ./02_tokens.sql.gz /docker-entrypoint-initdb.d/02_tokens.sql.gz


### PR DESCRIPTION
mysql default image removed "mysqlcheck" binary. Moving to mariadb brings that back.