### PR TITLE
Fixed kubeconfig file path for output variable

### DIFF
--- a/terraform/kubernetes-objects/output.tf
+++ b/terraform/kubernetes-objects/output.tf
@@ -1,5 +1,5 @@
 output "kubeconfig" {
-  value = abspath("${path.module}/${local_file.kubeconfig.filename}")
+  value = abspath("./${local_file.kubeconfig.filename}")
 }
 
 output "loadbalancer_hostname" {


### PR DESCRIPTION
The output displays the wrong location for the actual kubeconfig file. This fixes that output variable.